### PR TITLE
Add ability for custom attendance overrides

### DIFF
--- a/RTIScheduler_Upload_Att_to_eSchool.ps1
+++ b/RTIScheduler_Upload_Att_to_eSchool.ps1
@@ -33,6 +33,10 @@ if (!(Test-Path $currentPath\settings.ps1)) {
 
 . $currentPath\settings.ps1
 
+if ((Test-Path $currentPath\attendance_overrides.ps1)) {
+    . $currentPath\attendance_overrides.ps1
+}
+
 if ([int](Get-Date -Format MM) -ge 7) {
     $schoolyear = [int](Get-Date -Format yyyy) + 1
 } else {

--- a/RTIScheduler_Upload_Att_to_eSchool.ps1
+++ b/RTIScheduler_Upload_Att_to_eSchool.ps1
@@ -114,6 +114,10 @@ $eschool_buildings | ForEach-Object {
             #Append without headers. Uploads to eSchool do not have headers.
             $RTIAttendance += $RTIBuildingAttendance | ConvertTo-Csv -UseQuotes AsNeeded -NoTypeInformation | Select-Object -Skip 1
             if ($islinux) { $RTIAttendance +=  "`r`n" }
+            if (Test-Path "$currentPath\attendance_overrides.ps1") {
+                #Run the function to modify the attendance import
+            }
+            
 
             Invoke-RestMethod `
                 -Uri "https://rtischeduler.com/data-export-api/schools/$($rti_building_number)/attendance/finalize-by-date?date=$(Get-Date -Format "yyyy-MM-dd")" `

--- a/RTIScheduler_Upload_Att_to_eSchool.ps1
+++ b/RTIScheduler_Upload_Att_to_eSchool.ps1
@@ -119,7 +119,7 @@ $eschool_buildings | ForEach-Object {
             $RTIAttendance += $RTIBuildingAttendance | ConvertTo-Csv -UseQuotes AsNeeded -NoTypeInformation | Select-Object -Skip 1
             if ($islinux) { $RTIAttendance +=  "`r`n" }
             if (Test-Path "$currentPath\attendance_overrides.ps1") {
-                #Run the function to modify the attendance import
+                $RTIAttendance = Modify-Attendance -rawAttendance $RTIAttendance
             }
             
 

--- a/attendance_overrides-sample.ps1
+++ b/attendance_overrides-sample.ps1
@@ -1,7 +1,34 @@
+<#
+    If you need to make modifications to the attendance being pushed to eSchool, copy this file to ./attendance_overrides.ps1
+    Be extremely careful!
+    There is a sample function to exclude a period from being pushed to eSchool.  The example also includes the function calls for this to work.
+
+    1: Create modification functions at the bottom of the document.  Your function needs to take a parameter named $attendanceToUpdate and process the CSV information
+
+    2: Create a new declaration in the Modify-Attendance function that sets $attendanceToUpdate equal to the output of your custom function
+
+#>
+
+#Primary modification function:  List all of the function calls and variable reassignments here.
 Function Modify-Attendance {
-    Param($RTIAttendance)
-    $RTIAttendance | select-string -pattern 'H`|159'
+    Param($rawAttendance)
+    Write-Host "Running Attendance Modifications..."
+    $attendanceToUpdate = $rawAttendance
+#    $attendanceToUpdate = Exclude-Period -periodName "RTIC" -toUpdate $attendanceToUpdate  #Uncomment this line  AND CHANGE THE -periodName PARAM to use the provided Exclude-Period functi>
+    # Add $attendanceToUpdate declarations above this line.
+    # Do not edit the remainder of this function.
+    $updatedAttendance = $attendanceToUpdate
+    Write-Host "Finished running Attendance Modifications."
+    $updatedAttendance
 }
 
+#Create modification functions below.
 
-# get-content c:\new\temp_*.txt | select-string -pattern 'H`|159' -notmatch | Out-File c:\new\newfile.txt
+#Example: Remove attendance values for any record matching a provided period name (passed into the function as a parameter).
+
+Function Exclude-Period {
+    Param($periodName, $toUpdate)
+    Write-Host "Excluding Period " $periodName "from attendance..."
+    $modifiedAttendance = $toUpdate | where{$_ -notmatch "$periodName"}
+    $modifiedAttendance
+}

--- a/attendance_overrides-sample.ps1
+++ b/attendance_overrides-sample.ps1
@@ -1,0 +1,7 @@
+Function Modify-Attendance {
+    Param($RTIAttendance)
+    $RTIAttendance | select-string -pattern 'H`|159'
+}
+
+
+# get-content c:\new\temp_*.txt | select-string -pattern 'H`|159' -notmatch | Out-File c:\new\newfile.txt


### PR DESCRIPTION
This checks for the presence of attendance_overrides.ps1.  If it exists, it runs the Modify-Attendance function within that file.  The goal is to allow for schools to deal with odd setups without losing the ability to stay current with the latest git version.  I've included an example of using the script to remove a period named RTIC from the attendance upload.

If the file doesn't exist, the function doesn't run, and if a person does copy the file without understanding, it doesn't break the upload since no modifications are actually done by default.